### PR TITLE
Ios/refactor/network

### DIFF
--- a/ios/SideDishApp/SideDishApp/Network/NetworkManager.swift
+++ b/ios/SideDishApp/SideDishApp/Network/NetworkManager.swift
@@ -15,8 +15,8 @@ class NetworkManager {
         static let SideDishes = "https://h3rb9c0ugl.execute-api.ap-northeast-2.amazonaws.com/develop/baminchan"
     }
     
-    func getResource<T: Decodable>(from: String, path: String? = nil, type: T.Type, completion: @escaping (T?, Error?) -> ()) {
-        let pathURL = (path != nil) ? "/\(path!)" : ""
+    func getResource<T: Decodable>(from: String, path: String = "", type: T.Type, completion: @escaping (T?, Error?) -> ()) {
+        let pathURL = (path != "") ? "/\(path)" : ""
         let requestURL = from + pathURL
         AF.request(requestURL).responseDecodable(of: T.self, queue: .main, decoder: JSONDecoder()) { (response) in
             switch response.result {

--- a/ios/SideDishApp/SideDishApp/Network/NetworkManager.swift
+++ b/ios/SideDishApp/SideDishApp/Network/NetworkManager.swift
@@ -23,7 +23,7 @@ class NetworkManager {
     func getResource<T: Decodable>(from: String, path: String = "", type: T.Type, completion: @escaping (T?, Error?) -> ()) {
         let pathURL = (path != "") ? "/\(path)" : ""
         let requestURL = from + pathURL
-        AF.request(requestURL).responseDecodable(of: T.self, queue: .main, decoder: JSONDecoder()) { (response) in
+        AF.request(requestURL).responseDecodable(of: T.self, queue: .global(qos: .background), decoder: JSONDecoder()) { (response) in
             switch response.result {
             case .success(let decodedData):
                 completion(decodedData, nil)

--- a/ios/SideDishApp/SideDishApp/Network/NetworkManager.swift
+++ b/ios/SideDishApp/SideDishApp/Network/NetworkManager.swift
@@ -9,6 +9,11 @@
 import Foundation
 import Alamofire
 
+enum NetworkErrorCase : Error {
+    case InvalidURL
+    case NotFound
+}
+
 class NetworkManager {
     
     enum EndPoints {
@@ -28,9 +33,15 @@ class NetworkManager {
         }
     }
     
-    func fetchImage(from: String, completion: @escaping (Data?) -> Void) {
-        AF.request(from).responseData { (response) in
-            completion(response.data)
-        }
+    func fetchImage(from: String, completion: @escaping (Result<Data, NetworkErrorCase>) -> Void) {
+        let URLRequest = URL(string: from)!
+        URLSession.shared.dataTask(with: URLRequest) { (data, _, error) in
+            if error != nil { completion(.failure(.InvalidURL)) }
+            guard let data = data else {
+                completion(.failure(.InvalidURL))
+                return
+            }
+            completion(.success(data))
+        }.resume()
     }
 }

--- a/ios/SideDishApp/SideDishApp/ViewControllers/SideDishProductsViewController.swift
+++ b/ios/SideDishApp/SideDishApp/ViewControllers/SideDishProductsViewController.swift
@@ -42,7 +42,10 @@ class SideDishProductsViewController: UIViewController {
     
     private func fetchProducts(at section: Int, of category: Category) {
         networkManager.getResource(from: NetworkManager.EndPoints.SideDishes, path: category.path, type: ProductList.self) { (productList, error) in
-            if let error = error { print(error) }
+            if error != nil {
+                Toast(text: "네트워크 에러로 데이터를 불러올 수 없습니다.", delay: 0, duration: 3).show()
+                return
+            }
             guard let productList = productList else { return }
             DispatchQueue.main.async {
                 self.productsList[section] = Products(productList.products)

--- a/ios/SideDishApp/SideDishApp/ViewControllers/SideDishProductsViewController.swift
+++ b/ios/SideDishApp/SideDishApp/ViewControllers/SideDishProductsViewController.swift
@@ -108,11 +108,15 @@ extension SideDishProductsViewController: UITableViewDataSource {
         let products = productsList[indexPath.section]
         let product = products.product(at: indexPath.row)
         
-        networkManager.fetchImage(from: product.imageURL) { (data) in
-            guard let data = data else { return }
-            let image = UIImage(data: data)
-            DispatchQueue.main.async {
-                cell.configureProductImage(image)
+        networkManager.fetchImage(from: product.imageURL) { (result) in
+            switch result {
+            case .success(let data):
+                let image = UIImage(data: data)
+                DispatchQueue.main.async {
+                    cell.configureProductImage(image)
+                }
+            case .failure(_):
+                break
             }
         }
         cell.configureDetailHash(product.detailHash)

--- a/ios/SideDishApp/SideDishApp/Views/Product/ProductCell.swift
+++ b/ios/SideDishApp/SideDishApp/Views/Product/ProductCell.swift
@@ -46,7 +46,7 @@ class ProductCell: UITableViewCell {
     }
     
     private func configureImageView() {
-        productImageView.backgroundColor = UIColor(named: "keyColor")
+        productImageView.backgroundColor = UIColor(named: "subtitle-gray")
         productImageView.layer.cornerRadius = productImageView.frame.height / 2
     }
 }

--- a/ios/SideDishApp/SideDishApp/Views/Product/ProductCell.swift
+++ b/ios/SideDishApp/SideDishApp/Views/Product/ProductCell.swift
@@ -18,6 +18,8 @@ class ProductCell: UITableViewCell {
     @IBOutlet weak var priceLabelsStackView: PriceLabelsStackView!
     @IBOutlet weak var badgeLabelsStackView: BadgeLabelsStackView!
     
+    private var loadingColor: UIColor? = UIColor(named: "subtitle-gray")
+    
     private var detailHash: String!
     
     override func awakeFromNib() {
@@ -46,7 +48,11 @@ class ProductCell: UITableViewCell {
     }
     
     private func configureImageView() {
-        productImageView.backgroundColor = UIColor(named: "subtitle-gray")
+        productImageView.backgroundColor = loadingColor
         productImageView.layer.cornerRadius = productImageView.frame.height / 2
+    }
+    
+    override func prepareForReuse() {
+        productImageView.image = nil
     }
 }


### PR DESCRIPTION
피드백 일부 반영하였습니다.

반찬리스트 네트워크 요청을 글로벌 큐에 qos 클래스 프로퍼티를 background로 줬는데 이게 맞는 방식인가요?
background는 사용자가 직접 알지 못하는 작업을 표현한다고 하여 사용하였습니다. 정상적으로도 작동하는 것을 확인했습니다.

또한 에러 핸들링을 Toast를 사용하여 처리했습니다.