### PR TITLE
이미지 캐싱 구현

### DIFF
--- a/ios/SideDishApp/SideDishApp/Assets.xcassets/loading-color.colorset/Contents.json
+++ b/ios/SideDishApp/SideDishApp/Assets.xcassets/loading-color.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "red" : "0.891",
+          "alpha" : "1.000",
+          "blue" : "0.891",
+          "green" : "0.891"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "red" : "0.891",
+          "alpha" : "1.000",
+          "blue" : "0.891",
+          "green" : "0.891"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "red" : "0.660",
+          "alpha" : "1.000",
+          "blue" : "0.660",
+          "green" : "0.660"
+        }
+      }
+    }
+  ]
+}

--- a/ios/SideDishApp/SideDishApp/Network/NetworkManager.swift
+++ b/ios/SideDishApp/SideDishApp/Network/NetworkManager.swift
@@ -36,8 +36,7 @@ class NetworkManager {
     func fetchImage(from: String, completion: @escaping (Result<Data, NetworkErrorCase>) -> Void) {
         let fileName = String(from.split(separator: "/").last!)
         let cachedImageFileURL = try! FileManager.default
-            .url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
-        .appendingPathComponent(fileName)
+            .url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true).appendingPathComponent(fileName)
         let URLRequest = URL(string: from)!
         
         if let cachedData = try? Data(contentsOf: cachedImageFileURL) {

--- a/ios/SideDishApp/SideDishApp/Network/NetworkManager.swift
+++ b/ios/SideDishApp/SideDishApp/Network/NetworkManager.swift
@@ -35,12 +35,10 @@ class NetworkManager {
     
     func fetchImage(from: String, completion: @escaping (Result<Data, NetworkErrorCase>) -> Void) {
         let URLRequest = URL(string: from)!
-        URLSession.shared.dataTask(with: URLRequest) { (data, _, error) in
+        URLSession.shared.downloadTask(with: URLRequest) { (url, _, error) in
             if error != nil { completion(.failure(.InvalidURL)) }
-            guard let data = data else {
-                completion(.failure(.InvalidURL))
-                return
-            }
+            guard let url = url else { completion(.failure(.InvalidURL)); return }
+            guard let data = try? Data(contentsOf: url) else { completion(.failure(.InvalidURL)); return }
             completion(.success(data))
         }.resume()
     }

--- a/ios/SideDishApp/SideDishApp/Network/NetworkManager.swift
+++ b/ios/SideDishApp/SideDishApp/Network/NetworkManager.swift
@@ -34,7 +34,6 @@ class NetworkManager {
     }
     
     func fetchImage(from: String, completion: @escaping (Result<Data, NetworkErrorCase>) -> Void) {
-        
         let fileName = String(from.split(separator: "/").last!)
         let cachedImageFileURL = try! FileManager.default
             .url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)

--- a/ios/SideDishApp/SideDishApp/Network/NetworkManager.swift
+++ b/ios/SideDishApp/SideDishApp/Network/NetworkManager.swift
@@ -34,12 +34,25 @@ class NetworkManager {
     }
     
     func fetchImage(from: String, completion: @escaping (Result<Data, NetworkErrorCase>) -> Void) {
+        
+        let fileName = String(from.split(separator: "/").last!)
+        let cachedImageFileURL = try! FileManager.default
+            .url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        .appendingPathComponent(fileName)
         let URLRequest = URL(string: from)!
-        URLSession.shared.downloadTask(with: URLRequest) { (url, _, error) in
-            if error != nil { completion(.failure(.InvalidURL)) }
-            guard let url = url else { completion(.failure(.InvalidURL)); return }
-            guard let data = try? Data(contentsOf: url) else { completion(.failure(.InvalidURL)); return }
-            completion(.success(data))
-        }.resume()
+        
+        if let cachedData = try? Data(contentsOf: cachedImageFileURL) {
+            completion(.success(cachedData))
+            return
+        } else {
+            URLSession.shared.downloadTask(with: URLRequest) { (url, _, error) in
+                if error != nil { completion(.failure(.InvalidURL)) }
+                guard let url = url else { completion(.failure(.InvalidURL)); return }
+                guard let data = try? Data(contentsOf: url) else { completion(.failure(.InvalidURL)); return }
+                // temp url의 data를 cachedImageFileURL에 저장
+                try? FileManager.default.copyItem(at: url, to: cachedImageFileURL)
+                completion(.success(data))
+            }.resume()
+        }
     }
 }

--- a/ios/SideDishApp/SideDishApp/Network/NetworkManager.swift
+++ b/ios/SideDishApp/SideDishApp/Network/NetworkManager.swift
@@ -51,6 +51,7 @@ class NetworkManager {
                 guard let data = try? Data(contentsOf: url) else { completion(.failure(.InvalidURL)); return }
                 // temp url의 data를 cachedImageFileURL에 저장
                 try? FileManager.default.copyItem(at: url, to: cachedImageFileURL)
+                try? FileManager.default.removeItem(at: url)
                 completion(.success(data))
             }.resume()
         }

--- a/ios/SideDishApp/SideDishApp/Views/Product/ProductCell.swift
+++ b/ios/SideDishApp/SideDishApp/Views/Product/ProductCell.swift
@@ -18,7 +18,7 @@ class ProductCell: UITableViewCell {
     @IBOutlet weak var priceLabelsStackView: PriceLabelsStackView!
     @IBOutlet weak var badgeLabelsStackView: BadgeLabelsStackView!
     
-    private var loadingColor: UIColor? = UIColor(named: "subtitle-gray")
+    private var loadingColor: UIColor? = UIColor(named: "loading-color")
     
     override func awakeFromNib() {
         super.awakeFromNib()


### PR DESCRIPTION
이미지 캐싱을 구현하기 위해서 URLSession의 downloadTask를 사용하여 데이터를 받은 후에 cache 디렉토리에 저장하였습니다.

또한 fetchImage 메소드에서 먼저 저장된 이미지가 있는지 확인한 후에 없다면 이미지를 요청하도록 구현하였습니다.